### PR TITLE
graphics/atril: fix build without webkit

### DIFF
--- a/graphics/atril/files/patch-libview_ev-jobs.c
+++ b/graphics/atril/files/patch-libview_ev-jobs.c
@@ -1,0 +1,20 @@
+--- libview/ev-jobs.c.orig	2018-03-22 15:13:28 UTC
++++ libview/ev-jobs.c
+@@ -876,8 +876,6 @@ snapshot_callback(WebKitWebView *webview,
+ 	gtk_widget_destroy (gtk_widget_get_toplevel (GTK_WIDGET (webview)));
+ }
+ 
+-#endif  /* ENABLE_EPUB */
+-
+ static void
+ web_thumbnail_get_screenshot_cb (WebKitWebView  *webview,
+                                  WebKitLoadEvent event,
+@@ -909,6 +907,8 @@ webview_load_failed_cb (WebKitWebView  *webview,
+ 	gtk_widget_destroy (gtk_widget_get_toplevel (GTK_WIDGET (webview)));
+ 	return TRUE;
+ }
++
++#endif  /* ENABLE_EPUB */
+ 
+ static gboolean
+ ev_job_thumbnail_run (EvJob *job)


### PR DESCRIPTION
When `EPUB` is unset (ie epub support will not be built), this port shall not need `www/webkit2-gtk3`. However, due to a wrong placement of a preprocessor `endif`, two functions that directly use webkit are
exposed, causing builds without epub support to fail. This patch moves the preprocessor `endif` to the correct location.

This patch was obtained from upstream, specifically the commit immediately after v1.20.1.

Signed-off-by: Charlie Li <ml+freebsd at vishwin dot info>