### PR TITLE
devel/py-gobject3, graphics/py-cairo, devel/py-libpeas: correct plist for python 3.7

### DIFF
--- a/devel/py-gobject3/Makefile
+++ b/devel/py-gobject3/Makefile
@@ -13,5 +13,6 @@ PLIST=		${.CURDIR}/pkg-plist
 py34_PLIST=	${.CURDIR}/pkg-plist-py3
 py35_PLIST=	${.CURDIR}/pkg-plist-py3
 py36_PLIST=	${.CURDIR}/pkg-plist-py3
+py37_PLIST=	${.CURDIR}/pkg-plist-py3
 
 .include "${MASTERDIR}/Makefile"

--- a/devel/py-libpeas/Makefile
+++ b/devel/py-libpeas/Makefile
@@ -12,5 +12,6 @@ MASTERDIR=	${.CURDIR}/../../devel/libpeas/
 py34_PLIST=	${.CURDIR}/pkg-plist-py3
 py35_PLIST=	${.CURDIR}/pkg-plist-py3
 py36_PLIST=	${.CURDIR}/pkg-plist-py3
+py37_PLIST=	${.CURDIR}/pkg-plist-py3
 
 .include "${MASTERDIR}/Makefile"

--- a/graphics/py-cairo/Makefile
+++ b/graphics/py-cairo/Makefile
@@ -24,6 +24,7 @@ USE_GNOME=	cairo
 py34_PLIST=	${.CURDIR}/pkg-plist-py3
 py35_PLIST=	${.CURDIR}/pkg-plist-py3
 py36_PLIST=	${.CURDIR}/pkg-plist-py3
+py37_PLIST=	${.CURDIR}/pkg-plist-py3
 
 PLIST_SUB=	PORTVER=${PORTVERSION}
 


### PR DESCRIPTION
Otherwise when building the py37 flavour, the python 2 plist is used, which is obviously wrong.