### PR TITLE
Fix glib-mkenums Unicode issues

### DIFF
--- a/Mk/Uses/gnome.mk
+++ b/Mk/Uses/gnome.mk
@@ -66,6 +66,10 @@ _USES_POST+=	gnome
 IGNORE=	USES=gnome takes no arguments
 .endif
 
+# glib-mkenums often fails with C locale
+# https://gitlab.gnome.org/GNOME/glib/issues/1430
+USE_LOCALE?=	en_US.UTF-8
+
 # non-version specific components
 _USE_GNOME_ALL= esound intlhack intltool introspection \
 		referencehack gnomemimedata \

--- a/databases/libgda5/files/patch-unicode
+++ b/databases/libgda5/files/patch-unicode
@@ -1,0 +1,80 @@
+From b611c805b3a2248e2f4f85f993f96c13a05b4730 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Mon, 17 Jul 2017 22:37:50 +0100
+Subject: Convert files to Unicode
+
+These header files have mixed encoding, and makes various tools choke on
+them.
+---
+ libgda/gda-connection.h                          | 2 +-
+ libgda/sql-parser/gda-sql-statement.h            | 2 +-
+ libgda/sql-parser/gda-statement-struct-delete.h  | 2 +-
+ libgda/sql-parser/gda-statement-struct-unknown.h | 2 +-
+ libgda/sql-parser/gda-statement-struct-util.h    | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libgda/gda-connection.h b/libgda/gda-connection.h
+index 94d1b27b5..19ca63fc3 100644
+--- libgda/gda-connection.h.orig
++++ libgda/gda-connection.h
+@@ -6,7 +6,7 @@
+  * Copyright (C) 2002 - 2003 Gonzalo Paniagua Javier <gonzalo@ximian.com>
+  * Copyright (C) 2003 Filip Van Raemdonck <mechanix@debian.org>
+  * Copyright (C) 2004 - 2005 Alan Knowles <alank@src.gnome.org>
+- * Copyright (C) 2004 JosÈ MarÌa Casanova Crespo <jmcasanova@igalia.com>
++ * Copyright (C) 2004 Jos√© Mar√≠a Casanova Crespo <jmcasanova@igalia.com>
+  * Copyright (C) 2005 - 2009 Bas Driessen <bas.driessen@xobas.com>
+  * Copyright (C) 2006 - 2008 Murray Cumming <murrayc@murrayc.com>
+  * Copyright (C) 2007 Leonardo Boshell <lb@kmc.com.co>
+diff --git a/libgda/sql-parser/gda-sql-statement.h b/libgda/sql-parser/gda-sql-statement.h
+index 0ba1f9edc..8783ca8a1 100644
+--- libgda/sql-parser/gda-sql-statement.h.orig
++++ libgda/sql-parser/gda-sql-statement.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2000 Reinhard M√ºller <reinhard@src.gnome.org>
+  * Copyright (C) 2000 - 2002 Rodrigo Moya <rodrigo@gnome-db.org>
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@src.gnome.org>
+  * Copyright (C) 2011 Murray Cumming <murrayc@murrayc.com>
+diff --git a/libgda/sql-parser/gda-statement-struct-delete.h b/libgda/sql-parser/gda-statement-struct-delete.h
+index cab8b9dad..2e51c5eae 100644
+--- libgda/sql-parser/gda-statement-struct-delete.h.orig
++++ libgda/sql-parser/gda-statement-struct-delete.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2005 Dan Winship <danw@src.gnome.org>
+  * Copyright (C) 2005 - 2011 Vivien Malerba <malerba@gnome-db.org>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  * Copyright (C) 2007 Armin Burgmeier <armin@openismus.com>
+  * Copyright (C) 2007 - 2009 Murray Cumming <murrayc@murrayc.com>
+  *
+diff --git a/libgda/sql-parser/gda-statement-struct-unknown.h b/libgda/sql-parser/gda-statement-struct-unknown.h
+index 5c530d4d9..e0aaf945f 100644
+--- libgda/sql-parser/gda-statement-struct-unknown.h.orig
++++ libgda/sql-parser/gda-statement-struct-unknown.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2000 Reinhard M√ºller <reinhard@src.gnome.org>
+  * Copyright (C) 2000 - 2002 Rodrigo Moya <rodrigo@gnome-db.org>
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@src.gnome.org>
+  * Copyright (C) 2009 Murray Cumming <murrayc@murrayc.com>
+diff --git a/libgda/sql-parser/gda-statement-struct-util.h b/libgda/sql-parser/gda-statement-struct-util.h
+index cd4596281..252d6edcc 100644
+--- libgda/sql-parser/gda-statement-struct-util.h.orig
++++ libgda/sql-parser/gda-statement-struct-util.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2005 Dan Winship <danw@src.gnome.org>
+  * Copyright (C) 2005 - 2011 Vivien Malerba <malerba@gnome-db.org>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  * Copyright (C) 2007 - 2009 Murray Cumming <murrayc@murrayc.com>
+  *
+  * This library is free software; you can redistribute it and/or

--- a/databases/libgda5/files/patch-unicode-2
+++ b/databases/libgda5/files/patch-unicode-2
@@ -1,0 +1,103 @@
+Description: Fix FTBFS with glib 2.54
+ glib-mkenums now expects input files to be UTF-8,
+ fix the encoding of libgnomeui/gnome-scores.h
+Author: Adrian Bunk <bunk@debian.org>
+
+--- libgda/gda-column.h.orig
++++ libgda/gda-column.h
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (C) 2005 - 2011 Vivien Malerba <malerba@gnome-db.org>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  * Copyright (C) 2008 Przemys≈Çaw Grzegorczyk <pgrzegorczyk@gmail.com>
+  *
+  * This library is free software; you can redistribute it and/or
+--- libgda/gda-data-model-extra.h.orig
++++ libgda/gda-data-model-extra.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2003 Rodrigo Moya <rodrigo@gnome-db.org>
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 - 2003 Gonzalo Paniagua Javier <gonzalo@gnome-db.org>
+--- libgda/gda-data-model-iter-extra.h.orig
++++ libgda/gda-data-model-iter-extra.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2000 Reinhard M√ºller <reinhard@src.gnome.org>
+  * Copyright (C) 2000 - 2002 Rodrigo Moya <rodrigo@gnome-db.org>
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@src.gnome.org>
+  *
+--- libgda/gda-data-model.h.orig
++++ libgda/gda-data-model.h
+@@ -4,7 +4,7 @@
+  * Copyright (C) 2003 Laurent Sansonetti <lrz@gnome.org>
+  * Copyright (C) 2005 Dan Winship <danw@src.gnome.org>
+  * Copyright (C) 2005 - 2012 Vivien Malerba <malerba@gnome-db.org>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  * Copyright (C) 2007 Murray Cumming <murrayc@murrayc.com>
+  * Copyright (C) 2011 Daniel Espinosa <despinosa@src.gnome.org>
+  *
+--- libgda/gda-mutex.h.orig
++++ libgda/gda-mutex.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2000 Reinhard M√ºller <reinhard@src.gnome.org>
+  * Copyright (C) 2000 - 2002 Rodrigo Moya <rodrigo@gnome-db.org>
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2013 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@src.gnome.org>
+  *
+--- libgda/gda-row.h.orig
++++ libgda/gda-row.h
+@@ -3,10 +3,10 @@
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@gnome-db.org>
+  * Copyright (C) 2003 Laurent Sansonetti <laurent@datarescue.be>
+- * Copyright (C) 2003 Xabier RodrÌguez Calvar <xrcalvar@igalia.com>
++ * Copyright (C) 2003 Xabier Rodr√≠guez Calvar <xrcalvar@igalia.com>
+  * Copyright (C) 2004 Paisa  Seeluangsawat <paisa@users.sf.net>
+  * Copyright (C) 2005 Bas Driessen <bas.driessen@xobas.com>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+--- libgda/gda-server-provider-private.h.orig
++++ libgda/gda-server-provider-private.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2005 Dan Winship <danw@src.gnome.org>
+  * Copyright (C) 2005 - 2011 Vivien Malerba <malerba@gnome-db.org>
+- * Copyright (C) 2005 ¡lvaro PeÒa <alvaropg@telefonica.net>
++ * Copyright (C) 2005 √Ålvaro Pe√±a <alvaropg@telefonica.net>
+  * Copyright (C) 2007 Murray Cumming <murrayc@murrayc.com>
+  *
+  * This library is free software; you can redistribute it and/or
+--- libgda/gda-util.h.orig
++++ libgda/gda-util.h
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (C) 2000 Reinhard M√ºller <reinhard@src.gnome.org>
+  * Copyright (C) 2000 - 2002 Rodrigo Moya <rodrigo@gnome-db.org>
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2013 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 Gonzalo Paniagua Javier <gonzalo@src.gnome.org>
+  * Copyright (C) 2006 - 2007 Murray Cumming <murrayc@murrayc.com>
+--- libgda/libgda-global-variables.h.orig
++++ libgda/libgda-global-variables.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (C) 2001 Carlos PerellÛ MarÌn <carlos@gnome-db.org>
++ * Copyright (C) 2001 Carlos Perell√≥ Mar√≠n <carlos@gnome-db.org>
+  * Copyright (C) 2001 - 2003 Rodrigo Moya <rodrigo@gnome-db.org>
+  * Copyright (C) 2001 - 2011 Vivien Malerba <malerba@gnome-db.org>
+  * Copyright (C) 2002 - 2003 Gonzalo Paniagua Javier <gonzalo@gnome-db.org>


### PR DESCRIPTION
We need a UTF-8 locale: https://gitlab.gnome.org/GNOME/glib/issues/1430 — I figured the best place is `gnome.mk` — we have these in `meson.mk` and `gem.mk` already.

This fixes some [exp-run](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=229761) failures:

~~http://package22.nyi.freebsd.org/data/104amd64-default-PR229761/2018-07-19_19h24m12s/logs/errors/libgnome-2.32.1.log~~ hmm that doesn't use `gnome` or react to `USE_LOCALE`
http://package22.nyi.freebsd.org/data/104amd64-default-PR229761/2018-07-19_19h24m12s/logs/errors/mousetweaks-3.12.0_1.log

libgda5 actually had weird mixed encodings instead of UTF-8, I added patches I found in other distros for that. [Previously posted as [bug 226693](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=226693)]

http://package23.nyi.freebsd.org/data/104i386-default-PR229761/2018-07-19_19h24m20s/logs/errors/libgda5-5.2.4_2.log