### PR TITLE
devel/libsoup: add USES=ssl, caught by testport

### DIFF
--- a/devel/libsoup/Makefile
+++ b/devel/libsoup/Makefile
@@ -21,7 +21,7 @@ PORTSCOUT=	limitw:1,even
 .if !defined(REFERENCE_PORT)
 
 USES+=		gettext gmake gnome libtool pathfix pkgconfig \
-		python:build sqlite:3 tar:xz
+		python:build sqlite:3 ssl tar:xz
 USE_GNOME=	glib20 intlhack introspection:build \
 		libxml2 referencehack
 USE_LDCONFIG=	yes


### PR DESCRIPTION
This port dynamically links against ssl, so add to account for any `SONAME` changes or whatnot.

poudriere testport confirmed the problematic omission, but was first found when building `databases/evolution-data-server` with `ssl=libressl-devel`. The latest `security/libressl-devel` introduced a new `SONAME` in `libcrypto.so.44`, which causes this build error:

```
ld-elf.so.1: Shared object "libcrypto.so.43" not found, required by "libsoup-2.4.so.1"
Command '[u'/wrkdirs/usr/ports/databases/evolution-data-server/work/evolution-data-server-3.24.2/src/libedataserver/tmp-introspectX1LebG/EDataServer-1.2', u'--introspect-dump=/wrkdirs/usr/ports/databases/evolution-data-server/work/evolution-data-server-3.24.2/src/libedataserver/tmp-introspectX1LebG/functions.txt,/wrkdirs/usr/ports/databases/evolution-data-server/work/evolution-data-server-3.24.2/src/libedataserver/tmp-introspectX1LebG/dump.xml']' returned non-zero exit status 1
```