### PR TITLE
devel/gsettings-desktop-schemas: update (fixes lack of enum file)

### DIFF
--- a/devel/gsettings-desktop-schemas/Makefile
+++ b/devel/gsettings-desktop-schemas/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	gsettings-desktop-schemas
-PORTVERSION=	3.31.0.1
+PORTVERSION=	3.31.0.2
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -29,6 +29,7 @@ GLIB_SCHEMAS=	org.gnome.desktop.a11y.applications.gschema.xml \
 		org.gnome.desktop.calendar.gschema.xml \
 		org.gnome.desktop.default-applications.gschema.xml \
 		org.gnome.desktop.datetime.gschema.xml \
+		org.gnome.desktop.enums.xml \
 		org.gnome.desktop.input-sources.gschema.xml \
 		org.gnome.desktop.interface.gschema.xml \
 		org.gnome.desktop.lockdown.gschema.xml \

--- a/devel/gsettings-desktop-schemas/distinfo
+++ b/devel/gsettings-desktop-schemas/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1546554110
-SHA256 (gnome/gsettings-desktop-schemas-3.31.0.1.tar.xz) = 248ce64de76e99b840eac1060586db025b6d28d2a1f65037b90dff4e6d1a0903
-SIZE (gnome/gsettings-desktop-schemas-3.31.0.1.tar.xz) = 632084
+TIMESTAMP = 1548874249
+SHA256 (gnome/gsettings-desktop-schemas-3.31.0.2.tar.xz) = c676ebb5c2e15d7d4a2e13a57c3a32048e851c5961fb594b78f4458c2df59511
+SIZE (gnome/gsettings-desktop-schemas-3.31.0.2.tar.xz) = 637124

--- a/devel/gsettings-desktop-schemas/files/patch-meson.build
+++ b/devel/gsettings-desktop-schemas/files/patch-meson.build
@@ -1,0 +1,9 @@
+--- meson.build.orig	2019-01-30 19:51:49 UTC
++++ meson.build
+@@ -43,6 +43,3 @@ subdir('headers')
+ subdir('schemas')
+ subdir('po')
+ 
+-# Keep this in sync with post-install.py expected arguments
+-meson.add_install_script('build-aux/meson/post-install.py',
+-                         datadir)


### PR DESCRIPTION
- Update to 3.31.0.2 — important because 3.31.0.1 didn't install `org.gnome.desktop.enums.xml` with Meson, which is a huge problem (generation fails without enums)
- Do not run `post-install.py` (at least for me, it fails — and in general, we're doing the generation at package install time)